### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "github-actions"
       - "dependencies"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change modifies the schedule interval for GitHub Actions updates from weekly to monthly.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R6): Changed the interval for GitHub Actions updates from "weekly" to "monthly".